### PR TITLE
fix: README logo img link was broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Version: 0.12-SNAPSHOT
 ---
 
-<img align="right" width="100" height="140" src="https://github.com/devlinjunker/template.github.semver/raw/doc/main/img/logo-small.png">
+<img align="right" width="100" height="140" src="https://github.com/devlinjunker/template.github.semver/raw/develop/img/logo-small.png">
 
 # Template - Semantic Versioning with Github
 


### PR DESCRIPTION
# Description:
Image src link in README was wrong

# Related:
After #61 

# Visual:
<img width="813" alt="Screen Shot 2020-12-28 at 5 10 44 PM" src="https://user-images.githubusercontent.com/1504590/103251915-ad04de00-492f-11eb-8724-73bdf4f0574c.png">

# TODO:
 - [x] Updated README documents
 - [x] Complete PR Body
