### PR TITLE
fix: prefix needs to be lowercase so we can use git-mkver

### DIFF
--- a/.github/workflows/develop-verify-merge.yaml
+++ b/.github/workflows/develop-verify-merge.yaml
@@ -34,4 +34,4 @@ jobs:
       with:
         regex: '(\([\w\s]*\)*\))?:[\w\s]*'
         allowed_prefixes:  ${{ steps.extract_branch.outputs.prefix }}
-        prefix_case_sensitive: false
+        prefix_case_sensitive: true


### PR DESCRIPTION
# Description: <!-- Quickly describe what you are solving and how -->
PRS that use uppercase prefix in title will not be able to merge to proper commit message

# Related: <!-- Links to Related issues or documentation/references used for this change -->
Brings up the question for #55 - how will we add `BREAKING CHANGE` to commit message on `develop` branch

# Visual: <!-- Add a screenshot! -->
N/A

# TODO:
 - [x] Updated README documents
 - [x] Complete PR Body
