### PR TITLE
refactor: rename `hotfix` to `patch`

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,7 +41,7 @@ This directory contains files related to Github configurations and actions:
   - Creates new Release Tag and Github Release on `main` branch
   - Upmerges `develop` from `main` so the tag is in `develop`s history
 
-  ### Cut `hotfix-*` Branch Action (hotfix-cut.yaml)
+  ### Cut `hotfix-*` Branch Action (patch-cut.yaml)
   - Creates a new `hotfix-*` branch off of `main`, using the last tag to determine hotfix branch number and next version number
 
 

--- a/.github/workflows/main-verify-merge.yaml
+++ b/.github/workflows/main-verify-merge.yaml
@@ -7,21 +7,21 @@ on:
       - main
 
 jobs:
-  # Only allow `release-*` or `hotfix-*` branches to merge to `main`
+  # Only allow `release-*` or `patch-*` branches to merge to `main`
   verify-main:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: "Verify 'main' PR are from 'release-*' or 'hotfix-*' branch"
+    - name: "Verify 'main' PR are from 'release-*' or 'patch-*' branch"
       run: ./scripts/workflows/branch-match.sh
       env: 
         BRANCH: ${{ github.head_ref }}
-        REGEXP: (release-[0-9]+.[0-9]+|hotfix-[0-9]+.[0-9]+.[0-9]+)
+        REGEXP: (release-[0-9]+.[0-9]+|patch-[0-9]+.[0-9]+.[0-9]+)
 
-    - name: "Verify PR Title matches `release` or `hotfix` "
+    - name: "Verify PR Title matches `release` or `patch` "
       uses: deepakputhraya/action-pr-title@master
       with:
         regex: '-[0-9]+.[0-9]+(.[0-9]+)?'
-        allowed_prefixes:  release,hotfix
+        allowed_prefixes:  release,patch

--- a/.github/workflows/patch-cut.yml
+++ b/.github/workflows/patch-cut.yml
@@ -1,10 +1,10 @@
-name: "Hotfix-Cut"
+name: "Patch-Cut"
 
 # Workflow runs when manually triggered using the UI or API
 on: workflow_dispatch
  
 jobs:
-  cut-hotfix:
+  cut-patch:
     runs-on: ubuntu-latest
 
     steps: 
@@ -30,14 +30,14 @@ jobs:
       env:
         PATCH_VERSION: ${{ steps.version.outputs.patch }}
 
-    - name: "Create Hotfix Branch"
+    - name: "Create Patch Branch"
       run: |
         git config --global user.name 'Release Cut';
         git config --global user.email 'release@cut.com';
-        git checkout -b $HOTFIX_BRANCH;
-        ./scripts/release/update-versions.sh $HOTFIX_VERSION;
-        git commit -a -m "update version for $HOTFIX_BRANCH";
-        git push --set-upstream origin $HOTFIX_BRANCH;
+        git checkout -b $PATCH_BRANCH;
+        ./scripts/release/update-versions.sh $PATCH_VERSION;
+        git commit -a -m "update version for $PATCH_BRANCH";
+        git push --set-upstream origin $PATCH_BRANCH;
       env:
-        HOTFIX_BRANCH: hotfix-${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.next_version.outputs.patch }}
-        HOTFIX_VERSION: ${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.next_version.outputs.patch }}
+        PATCH_BRANCH: patch-${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.next_version.outputs.patch }}
+        PATCH_VERSION: ${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.next_version.outputs.patch }}


### PR DESCRIPTION
**NOTE: THIS SHOULD CAUSE MAJOR RELEASE**

# Description: <!-- Quickly describe what you are solving and how -->
Initially used moniker `hotfix` for branches off of `main` that increment minor version only

# Related: <!-- Links to Related issues or documentation/references used for this change -->
This will create a major release cut (so do #55)
related #53

# Visual: <!-- Add a screenshot! -->
N/A

# TODO:
 - [x] Complete PR Body
 - [x] Complete Wikis
    - Release
    - Testing
    - Update FAQ
    - Tools
    - Styleguide
 - [x] **MANUALLY SQUASH MERGE WITH** `BREAKING CHANGE` FOOTER
 - **after merge** Test that `patch-*` branch created
 - **after merge** delete `hotfix` branches? delete `master` branch?
 - **after all else** cut major release branch