### PR TITLE
bug: Wiki Sync README - Use Header in ToC

### DIFF
--- a/scripts/workflows/collect-wiki.sh
+++ b/scripts/workflows/collect-wiki.sh
@@ -21,7 +21,7 @@ do
     
     wiki_title=$(less $f | awk '{ if (NR == 1) print }' | sed "s/# //") 
     link=$(echo $f | sed "s/^\.\///" | sed "s/^\.//" | sed "s/^/_/" | sed "s/\//_/g" | sed "s/\.md$/_README/")
-    echo "- [$wiki_title - $f]($link)" >> wiki/.README-\(synced\).md
+    echo "- [$wiki_title ($f)]($link)" >> wiki/.README-\(synced\).md
 done
 
 # find files in repo with README in name
@@ -38,5 +38,5 @@ do
     
     wiki_title=$(less $f | awk '{ if (NR == 1) print }' | sed "s/# //") 
     link=$(echo $f | sed "s/^\.\///" | sed "s/^\.//" | sed "s/^/_/" | sed "s/\//_/g" | sed "s/\.md$//")
-    echo "- [$wiki_title - $f]($link)" >> wiki/.README-\(synced\).md
+    echo "- [$wiki_title ($f)]($link)" >> wiki/.README-\(synced\).md
 done

--- a/scripts/workflows/collect-wiki.sh
+++ b/scripts/workflows/collect-wiki.sh
@@ -14,12 +14,14 @@ OTHER_FILES=("./CONTRIBUTING.md" "./SECURITY.md")
 
 for f in "${OTHER_FILES[@]}"
 do
-    echo $f;
+    echo $f; # print file name so we can see the files being copied in workflow logs
     # rename each to `_<directory>_README` and place in `wiki/` directory 
     wiki_name=$(echo $f | sed "s/^\.\///" | sed "s/^\.//" | sed "s/^/_/" | sed "s/\//_/g" | sed "s/\.md$/_README.md/")
     cp $f wiki/$wiki_name
+    
+    wiki_title=$(less $f | awk '{ if (NR == 1) print }' | sed "s/# //") 
     link=$(echo $f | sed "s/^\.\///" | sed "s/^\.//" | sed "s/^/_/" | sed "s/\//_/g" | sed "s/\.md$/_README/")
-    echo "- [$f]($link)" >> wiki/.README-\(synced\).md
+    echo "- [$wiki_title - $f]($link)" >> wiki/.README-\(synced\).md
 done
 
 # find files in repo with README in name
@@ -27,12 +29,14 @@ README_FILES=$( find . -name *README* );
 
 for f in ${README_FILES[@]}
 do
+    echo $f; # print file name so we can see the files being copied in workflow logs
     if [ "$f" = "./README.md" ]; then continue; fi
-    echo $f;
+    
     # rename each to `_<directory>_README` and place in `wiki/` directory 
     wiki_name=$(echo $f | sed "s/^\.\///" | sed "s/^\.//" | sed "s/^/_/" | sed "s/\//_/g")
     cp $f wiki/$wiki_name
-
+    
+    wiki_title=$(less $f | awk '{ if (NR == 1) print }' | sed "s/# //") 
     link=$(echo $f | sed "s/^\.\///" | sed "s/^\.//" | sed "s/^/_/" | sed "s/\//_/g" | sed "s/\.md$//")
-    echo "- [$f]($link)" >> wiki/.README-\(synced\).md
+    echo "- [$wiki_title - $f]($link)" >> wiki/.README-\(synced\).md
 done


### PR DESCRIPTION
# Description: <!-- Quickly describe what you are solving and how -->
Use the Header of README in the README Table of Contents so its easier to see how this looks

# Related: <!-- Links to Related issues or documentation/references used for this change -->
#81 

# Visual: <!-- Add a screenshot! -->
<img width="515" alt="Screen Shot 2021-03-21 at 3 31 45 PM" src="https://user-images.githubusercontent.com/1504590/111923067-8e0f7700-8a5a-11eb-8379-0ddb2a1fbe00.png">

# TODO:
 - ~[ ] Updated README documents~
 - [x] Complete PR Body
