### PR TITLE
patch-1.7.2

### DIFF
--- a/.github/workflows/develop-verify-merge.yaml
+++ b/.github/workflows/develop-verify-merge.yaml
@@ -36,5 +36,5 @@ jobs:
       uses: deepakputhraya/action-pr-title@master
       with:
         regex: '(\([\w\s]*\)*\))?:[\w\s]*'
-        allowed_prefixes:  ${{ steps.extract_branch.outputs.prefix }},build
+        allowed_prefixes:  ${{ steps.extract_branch.outputs.prefix }},build # add build to not fail dependabot PRs
         prefix_case_sensitive: true

--- a/.github/workflows/develop-verify-merge.yaml
+++ b/.github/workflows/develop-verify-merge.yaml
@@ -36,5 +36,5 @@ jobs:
       uses: deepakputhraya/action-pr-title@master
       with:
         regex: '(\([\w\s]*\)*\))?:[\w\s]*'
-        allowed_prefixes:  ${{ steps.extract_branch.outputs.prefix }}
+        allowed_prefixes:  ${{ steps.extract_branch.outputs.prefix }},build
         prefix_case_sensitive: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-Version: 1.7.0
+Version: 1.7.2
 ---
 
 <img align="right" width="100" height="140" src="https://github.com/devlinjunker/template.github.semver/raw/develop/img/logo-small.png" alt="semver template logo">


### PR DESCRIPTION
## Description:
Dependabot PRs are failing due to invalid PR title prefix:

![Screen Shot 2021-07-17 at 2 32 53 PM](https://user-images.githubusercontent.com/1504590/126049827-817b9a73-6c79-4a77-b604-132b9f16a806.png)


## Fix:
Allow PRs with `build` prefix